### PR TITLE
Show role mode if Hide Game Settings is OFF

### DIFF
--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -256,6 +256,18 @@ public static class Utils
     {
         return GetRoleString(Enum.GetName(typeof(CustomRoles), role), forUser);
     }
+    public static string GetRoleMode(CustomRoles role, bool parentheses = true)
+    {
+        if (Options.HideGameSettings.GetBool() && Main.AllPlayerControls.Count() > 1)
+            return string.Empty;
+        string mode = role.GetMode() switch
+        {
+            0 => GetString("RoleOffNoColor"),
+            1 => GetString("RoleRateNoColor"),
+            _ => GetString("RoleOnNoColor")
+        };
+        return parentheses ? $"({mode})" : mode;
+    }
     public static string GetDeathReason(PlayerState.DeathReason status)
     {
         return GetString("DeathReason." + Enum.GetName(typeof(PlayerState.DeathReason), status));
@@ -512,7 +524,7 @@ public static class Utils
         if (Options.EnableGM.GetBool()) { SendMessage(GetRoleName(CustomRoles.GM) + GetString("GMInfoLong"), PlayerId); }
         foreach (var role in Enum.GetValues(typeof(CustomRoles)).Cast<CustomRoles>())
         {
-            if (role.IsEnable() && !role.IsVanilla()) SendMessage(GetRoleName(role) + GetString(Enum.GetName(typeof(CustomRoles), role) + "InfoLong"), PlayerId);
+            if (role.IsEnable() && !role.IsVanilla()) SendMessage(GetRoleName(role) + GetRoleMode(role) + GetString(Enum.GetName(typeof(CustomRoles), role) + "InfoLong"), PlayerId);
         }
 
         if (Options.NoGameEnd.GetBool()) { SendMessage(GetString("NoGameEndInfo"), PlayerId); }

--- a/Patches/ChatCommandPatch.cs
+++ b/Patches/ChatCommandPatch.cs
@@ -190,15 +190,15 @@ internal class ChatCommands
                     {
                         var lp = PlayerControl.LocalPlayer;
                         var sb = new StringBuilder();
-                        sb.Append(GetString(role.ToString()) + lp.GetRoleInfo(true));
+                        sb.Append(GetString(role.ToString()) + Utils.GetRoleMode(role) + lp.GetRoleInfo(true));
                         if (Options.CustomRoleSpawnChances.TryGetValue(role, out var opt))
                             Utils.ShowChildrenSettings(Options.CustomRoleSpawnChances[role], ref sb, command: true);
                         var txt = sb.ToString();
                         sb.Clear().Append(txt.RemoveHtmlTags());
                         foreach (var subRole in Main.PlayerStates[lp.PlayerId].SubRoles)
-                            sb.Append($"\n\n" + GetString($"{subRole}") + GetString($"{subRole}InfoLong"));
+                            sb.Append($"\n\n" + GetString($"{subRole}") + Utils.GetRoleMode(subRole) + GetString($"{subRole}InfoLong"));
                         if (CustomRolesHelper.RoleExist(CustomRoles.Ntr) && (role is not CustomRoles.GM and not CustomRoles.Ntr))
-                            sb.Append($"\n\n" + GetString($"Lovers") + GetString($"LoversInfoLong"));
+                            sb.Append($"\n\n" + GetString($"Lovers") + Utils.GetRoleMode(CustomRoles.Lovers) + GetString($"LoversInfoLong"));
                         Utils.SendMessage(sb.ToString(), lp.PlayerId);
                     }
                     else
@@ -580,7 +580,7 @@ internal class ChatCommands
                     if (isUp) return;
                 }
                 var sb = new StringBuilder();
-                sb.Append(devMark + roleName + GetString($"{rl}InfoLong"));
+                sb.Append(devMark + roleName + Utils.GetRoleMode(rl) + GetString($"{rl}InfoLong"));
                 if (Options.CustomRoleSpawnChances.ContainsKey(rl))
                 {
                     Utils.ShowChildrenSettings(Options.CustomRoleSpawnChances[rl], ref sb, command: true);
@@ -653,15 +653,15 @@ internal class ChatCommands
                 if (GameStates.IsInGame)
                 {
                     var sb = new StringBuilder();
-                    sb.Append(GetString(role.ToString()) + player.GetRoleInfo(true));
+                    sb.Append(GetString(role.ToString()) + Utils.GetRoleMode(role) + player.GetRoleInfo(true));
                     if (Options.CustomRoleSpawnChances.TryGetValue(role, out var opt))
                         Utils.ShowChildrenSettings(Options.CustomRoleSpawnChances[role], ref sb, command: true);
                     var txt = sb.ToString();
                     sb.Clear().Append(txt.RemoveHtmlTags());
                     foreach (var subRole in Main.PlayerStates[player.PlayerId].SubRoles)
-                        sb.Append($"\n\n" + GetString($"{subRole}") + GetString($"{subRole}InfoLong"));
+                        sb.Append($"\n\n" + GetString($"{subRole}") + Utils.GetRoleMode(subRole) + GetString($"{subRole}InfoLong"));
                     if (CustomRolesHelper.RoleExist(CustomRoles.Ntr) && (role is not CustomRoles.GM and not CustomRoles.Ntr))
-                        sb.Append($"\n\n" + GetString($"Lovers") + GetString($"LoversInfoLong"));
+                        sb.Append($"\n\n" + GetString($"Lovers") + Utils.GetRoleMode(CustomRoles.Lovers) + GetString($"LoversInfoLong"));
                     Utils.SendMessage(sb.ToString(), player.PlayerId);
                 }
                 else

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -489,15 +489,15 @@ class MeetingHudStartPatch
             {
                 var role = pc.GetCustomRole();
                 var sb = new StringBuilder();
-                sb.Append(GetString(role.ToString()) + pc.GetRoleInfo(true));
+                sb.Append(GetString(role.ToString()) + Utils.GetRoleMode(role) + pc.GetRoleInfo(true));
                 if (Options.CustomRoleSpawnChances.TryGetValue(role, out var opt))
                     Utils.ShowChildrenSettings(opt, ref sb, command: true);
                 var txt = sb.ToString();
                 sb.Clear().Append(txt.RemoveHtmlTags());
                 foreach (var subRole in Main.PlayerStates[pc.PlayerId].SubRoles)
-                    sb.Append($"\n\n" + GetString($"{subRole}") + GetString($"{subRole}InfoLong"));
+                    sb.Append($"\n\n" + GetString($"{subRole}") + Utils.GetRoleMode(subRole) + GetString($"{subRole}InfoLong"));
                 if (CustomRolesHelper.RoleExist(CustomRoles.Ntr) && (role is not CustomRoles.GM and not CustomRoles.Ntr))
-                    sb.Append($"\n\n" + GetString($"Lovers") + GetString($"LoversInfoLong"));
+                    sb.Append($"\n\n" + GetString($"Lovers") + Utils.GetRoleMode(CustomRoles.Lovers) + GetString($"LoversInfoLong"));
                 AddMsg(sb.ToString(), pc.PlayerId);
             }
         if (msgToSend.Count >= 1)


### PR DESCRIPTION
Adds role mode (Disabled/Random/Always) to role text.

Example where it can be useful:
Jackal kills Crew and claims Sheriff. You want to quickly check if Sheriff is enabled so you type `/r sheriff`. It's disabled. You just caught a Jackal!

This method is quicker than typing `/r` or `/n r` and trying to find a specific role's mode on the list.

Hide Game Settings ON exception:
If player count equals 1 role mode is shown even when Hide Game Settings is enabled. This is because only host can see it then.