### PR TITLE
Fix bug comm camouflage

### DIFF
--- a/Modules/Camouflague.cs
+++ b/Modules/Camouflague.cs
@@ -56,21 +56,9 @@ public static class Camouflage
 
         if (oldIsCamouflage != IsCamouflage)
         {
-            if (Concealer.IsHidding)
-            {
-                Main.AllPlayerControls.Do(pc => RpcSetSkin(pc));
-                Utils.NotifyRoles(ForceLoop: true);
-            }
-            else
-            {
-                new LateTask(
-                () =>
-                {
-                    Main.AllPlayerControls.Do(pc => RpcSetSkin(pc));
-                    if (GameStates.IsMeeting)
-                    { Utils.NotifyRoles(ForceLoop: true); }
-                }, 0.1f, "Camouflage");
-            }
+            Main.AllPlayerControls.Do(pc => RpcSetSkin(pc));
+                if (GameStates.IsMeeting)
+                { Utils.NotifyRoles(ForceLoop: true); }
         }
     }
     public static void RpcSetSkin(PlayerControl target, bool ForceRevert = false, bool RevertToDefault = false)

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -954,7 +954,7 @@ public static class Utils
     private static StringBuilder SelfMark = new(20);
     private static StringBuilder TargetSuffix = new();
     private static StringBuilder TargetMark = new(20);
-    public static void NotifyRoles(bool isForMeeting = false, PlayerControl SpecifySeer = null, bool NoCache = false, bool ForceLoop = false)
+    public static void NotifyRoles(bool isForMeeting = false, PlayerControl SpecifySeer = null, bool NoCache = false, bool ForceLoop = false, bool CamouflageisForMeeting = false, bool CamouflageIsActive = false)
     {
         if (!AmongUsClient.Instance.AmHost) return;
         if (Main.AllPlayerControls == null) return;
@@ -1086,8 +1086,17 @@ public static class Utils
             }
             else SelfName = SelfRoleName + "\r\n" + SelfName;
             SelfName += SelfSuffix.ToString() == "" ? "" : "\r\n " + SelfSuffix.ToString();
-            if (((IsActive(SystemTypes.Comms) && Options.CommsCamouflage.GetBool()) || Concealer.IsHidding) && !isForMeeting)
-                SelfName = SelfRoleName;
+
+            string SelfNameCC = SelfName;
+
+            //The player's own nickname disappears during camouflage
+            if (((IsActive(SystemTypes.Comms) && Options.CommsCamouflage.GetBool()) || Concealer.IsHidding) && CamouflageisForMeeting && CamouflageIsActive)
+            { SelfName = SelfNameCC; }
+
+            //The player's own nickname is returned during the meeting when the camouflage is active
+            else if (((IsActive(SystemTypes.Comms) && Options.CommsCamouflage.GetBool()) || Concealer.IsHidding) && !GameStates.IsMeeting && !CamouflageIsActive)
+            { SelfName = SelfRoleName; }
+
             if (!isForMeeting) SelfName += "\r\n";
 
             //適用
@@ -1215,6 +1224,7 @@ public static class Utils
 
                 //ターゲットのプレイヤー名の色を書き換えます。
                 TargetPlayerName = TargetPlayerName.ApplyNameColorData(seer, target, isForMeeting);
+                string TargetPlayerNameCC = TargetPlayerName;
 
                 if (seer.Is(CustomRoleTypes.Impostor) && target.Is(CustomRoles.Snitch) && target.Is(CustomRoles.Madmate) && target.GetPlayerTaskState().IsTaskFinished)
                     TargetMark.Append(ColorString(GetRoleColor(CustomRoles.Impostor), "★"));
@@ -1237,8 +1247,17 @@ public static class Utils
                 if (seer.KnowDeathReason(target))
                     TargetDeathReason = $"({ColorString(GetRoleColor(CustomRoles.Doctor), GetVitalText(target.PlayerId))})";
 
-                if (((IsActive(SystemTypes.Comms) && Options.CommsCamouflage.GetBool()) || Concealer.IsHidding) && !isForMeeting)
-                    TargetPlayerName = $"<size=0%>{TargetPlayerName}</size>";
+                //During Сamouflage nicknames disappears
+                if (((IsActive(SystemTypes.Comms) && Options.CommsCamouflage.GetBool()) || Concealer.IsHidding) && ForceLoop && !GameStates.IsMeeting)
+                { TargetPlayerName = $"<size=0%>{TargetPlayerName}</size> "; }
+                if (((IsActive(SystemTypes.Comms) && Options.CommsCamouflage.GetBool()) || Concealer.IsHidding) && !ForceLoop && GameStates.IsMeeting)
+                { TargetPlayerName = $"<size=0%>{TargetPlayerName}</size> "; }
+                if (((IsActive(SystemTypes.Comms) && Options.CommsCamouflage.GetBool()) || Concealer.IsHidding) && !ForceLoop)
+                { TargetPlayerName = $"<size=0%>{TargetPlayerName}</size> "; }
+
+                //When the meeting starts during Camouflage, nicknames are returned to their place
+                if (((IsActive(SystemTypes.Comms) && Options.CommsCamouflage.GetBool()) || Concealer.IsHidding) && CamouflageisForMeeting && CamouflageIsActive)
+                { TargetPlayerName = TargetPlayerNameCC; }
 
                 //全てのテキストを合成します。
                 string TargetName = $"{TargetRoleText}{TargetPlayerName}{TargetDeathReason}{TargetMark}";

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -961,6 +961,7 @@ class ReportDeadBodyPatch
         Main.MadGrenadierBlinding.Clear();
         Divinator.didVote.Clear();
 
+        Concealer.OnReportDeadBody();
         Psychic.OnReportDeadBody();
         BountyHunter.OnReportDeadBody();
         SerialKiller.OnReportDeadBody();
@@ -994,8 +995,6 @@ class ReportDeadBodyPatch
         Main.RevolutionistLastTime.Clear();
         #endregion
 
-        Concealer.OnReportDeadBody();
-
         Main.AllPlayerControls
             .Where(pc => Main.CheckShapeshift.ContainsKey(pc.PlayerId))
             .Do(pc => Camouflage.RpcSetSkin(pc, RevertToDefault: true));
@@ -1006,7 +1005,10 @@ class ReportDeadBodyPatch
 
         Utils.SyncAllSettings();
 
-        if ((Utils.IsActive(SystemTypes.Comms) && Options.CommsCamouflage.GetBool()) || Concealer.IsHidding)
+        if(Concealer.IsHidding && !(Utils.IsActive(SystemTypes.Comms) && Options.CommsCamouflage.GetBool()))
+            Main.AllPlayerControls.Do(pc => Camouflage.RpcSetSkin(pc, ForceRevert: true, RevertToDefault: true));
+
+        if (Utils.IsActive(SystemTypes.Comms) && Options.CommsCamouflage.GetBool())
             { Utils.NotifyRoles(CamouflageisForMeeting: true, CamouflageIsActive: true); }
     }
     public static async void ChangeLocalNameAndRevert(string name, int time)

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -961,7 +961,6 @@ class ReportDeadBodyPatch
         Main.MadGrenadierBlinding.Clear();
         Divinator.didVote.Clear();
 
-        Concealer.OnReportDeadBody();
         Psychic.OnReportDeadBody();
         BountyHunter.OnReportDeadBody();
         SerialKiller.OnReportDeadBody();
@@ -995,6 +994,8 @@ class ReportDeadBodyPatch
         Main.RevolutionistLastTime.Clear();
         #endregion
 
+        Concealer.OnReportDeadBody();
+
         Main.AllPlayerControls
             .Where(pc => Main.CheckShapeshift.ContainsKey(pc.PlayerId))
             .Do(pc => Camouflage.RpcSetSkin(pc, RevertToDefault: true));
@@ -1004,6 +1005,9 @@ class ReportDeadBodyPatch
         Utils.NotifyRoles(isForMeeting: true, NoCache: true);
 
         Utils.SyncAllSettings();
+
+        if ((Utils.IsActive(SystemTypes.Comms) && Options.CommsCamouflage.GetBool()) || Concealer.IsHidding)
+            { Utils.NotifyRoles(CamouflageisForMeeting: true, CamouflageIsActive: true); }
     }
     public static async void ChangeLocalNameAndRevert(string name, int time)
     {

--- a/Patches/SabotageSystemPatch.cs
+++ b/Patches/SabotageSystemPatch.cs
@@ -1,5 +1,4 @@
 using HarmonyLib;
-using TOHE.Roles.Impostor;
 
 namespace TOHE;
 

--- a/Patches/SabotageSystemPatch.cs
+++ b/Patches/SabotageSystemPatch.cs
@@ -1,4 +1,5 @@
 using HarmonyLib;
+using TOHE.Roles.Impostor;
 
 namespace TOHE;
 
@@ -39,8 +40,16 @@ public static class ElectricTaskInitializePatch
     public static void Postfix()
     {
         Utils.MarkEveryoneDirtySettings();
-        if (!GameStates.IsMeeting)
-            Utils.NotifyRoles(ForceLoop: true);
+        if (Concealer.IsHidding)
+        {
+            if (!GameStates.IsMeeting)
+                Utils.NotifyRoles(ForceLoop: true);
+        }
+        else
+        {
+            if (!GameStates.IsMeeting)
+                Utils.NotifyRoles();
+        }
     }
 }
 [HarmonyPatch(typeof(ElectricTask), nameof(ElectricTask.Complete))]
@@ -49,7 +58,15 @@ public static class ElectricTaskCompletePatch
     public static void Postfix()
     {
         Utils.MarkEveryoneDirtySettings();
-        if (!GameStates.IsMeeting)
-            Utils.NotifyRoles(ForceLoop: true);
+        if (Concealer.IsHidding)
+        {
+            if (!GameStates.IsMeeting)
+                Utils.NotifyRoles(ForceLoop: true);
+        }
+        else
+        {
+            if (!GameStates.IsMeeting)
+                Utils.NotifyRoles();
+        }
     }
 }

--- a/Patches/SabotageSystemPatch.cs
+++ b/Patches/SabotageSystemPatch.cs
@@ -40,16 +40,8 @@ public static class ElectricTaskInitializePatch
     public static void Postfix()
     {
         Utils.MarkEveryoneDirtySettings();
-        if (Concealer.IsHidding)
-        {
-            if (!GameStates.IsMeeting)
-                Utils.NotifyRoles(ForceLoop: true);
-        }
-        else
-        {
-            if (!GameStates.IsMeeting)
-                Utils.NotifyRoles();
-        }
+        if (!GameStates.IsMeeting)
+            Utils.NotifyRoles();
     }
 }
 [HarmonyPatch(typeof(ElectricTask), nameof(ElectricTask.Complete))]
@@ -58,15 +50,7 @@ public static class ElectricTaskCompletePatch
     public static void Postfix()
     {
         Utils.MarkEveryoneDirtySettings();
-        if (Concealer.IsHidding)
-        {
-            if (!GameStates.IsMeeting)
-                Utils.NotifyRoles(ForceLoop: true);
-        }
-        else
-        {
-            if (!GameStates.IsMeeting)
-                Utils.NotifyRoles();
-        }
+        if (!GameStates.IsMeeting)
+            Utils.NotifyRoles();
     }
 }

--- a/Patches/ShipStatusPatch.cs
+++ b/Patches/ShipStatusPatch.cs
@@ -80,14 +80,7 @@ class RepairSystemPatch
     }
     public static void Postfix(ShipStatus __instance)
     {
-        if (Concealer.IsHidding)
-        {
-            if (!GameStates.IsMeeting)
-            { Utils.NotifyRoles(ForceLoop: true); }
-            Camouflage.CheckCamouflage(); 
-        }
-
-        else
+        if (Utils.IsActive(SystemTypes.Comms) && Options.CommsCamouflage.GetBool())
         {
             new LateTask(
             () =>
@@ -95,7 +88,14 @@ class RepairSystemPatch
                 Camouflage.CheckCamouflage();
                 if (!GameStates.IsMeeting)
                 { Utils.NotifyRoles(ForceLoop: true); }
+
             }, 0.1f, "ShipStatus.RepairSystem");
+        }
+        else
+        {
+            Camouflage.CheckCamouflage();
+            if (!GameStates.IsMeeting)
+            { Utils.NotifyRoles(ForceLoop: true); }
         }
     }
     public static void CheckAndOpenDoorsRange(ShipStatus __instance, int amount, int min, int max)

--- a/Patches/ShipStatusPatch.cs
+++ b/Patches/ShipStatusPatch.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using TOHE.Roles.Crewmate;
-using TOHE.Roles.Impostor;
 using TOHE.Roles.Neutral;
 using UnityEngine;
 

--- a/Patches/ShipStatusPatch.cs
+++ b/Patches/ShipStatusPatch.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using TOHE.Roles.Crewmate;
+using TOHE.Roles.Impostor;
 using TOHE.Roles.Neutral;
 using UnityEngine;
 
@@ -79,7 +80,23 @@ class RepairSystemPatch
     }
     public static void Postfix(ShipStatus __instance)
     {
-        Camouflage.CheckCamouflage();
+        if (Concealer.IsHidding)
+        {
+            if (!GameStates.IsMeeting)
+            { Utils.NotifyRoles(ForceLoop: true); }
+            Camouflage.CheckCamouflage(); 
+        }
+
+        else
+        {
+            new LateTask(
+            () =>
+            {
+                Camouflage.CheckCamouflage();
+                if (!GameStates.IsMeeting)
+                { Utils.NotifyRoles(ForceLoop: true); }
+            }, 0.1f, "ShipStatus.RepairSystem");
+        }
     }
     public static void CheckAndOpenDoorsRange(ShipStatus __instance, int amount, int min, int max)
     {

--- a/Roles/Impostor/Concealer.cs
+++ b/Roles/Impostor/Concealer.cs
@@ -57,6 +57,5 @@ public static class Concealer
     {
         HiddenCount = 0;
         SendRPC();
-        Camouflage.CheckCamouflage();
     }
 }

--- a/Roles/Impostor/Concealer.cs
+++ b/Roles/Impostor/Concealer.cs
@@ -57,5 +57,6 @@ public static class Concealer
     {
         HiddenCount = 0;
         SendRPC();
+        Camouflage.CheckCamouflage();
     }
 }


### PR DESCRIPTION
Since the mod will soon cease to be supported, I want to add fixes with camouflage (I checked during the game and everything works fine)

Fixed bugs like:
1. When someone was killed during camouflage, all players had nicknames visible

2. During the meeting, the nicknames of all players were invisible (returned only at the host)

3. When "KPDCamouflageMode" was enabled it would only activate when the host re-logged into the game