### PR TITLE
Fix workflow `Assign self to pull request`

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -8,21 +8,12 @@ permissions:
   pull-requests: write
 
 jobs:
-  assign_self_to_pull_request:
-    if: ${{ github.actor != 'dependabot[bot]' }}
+  assign:
+    name: Assign self to pull request
     runs-on: ubuntu-latest
-    env:
-      GH_TOKEN: ${{ github.token }}
-      GH_REPO: ${{ github.repository }}
-      NUMBER: ${{ github.event.pull_request.number }}
-      ASSIGNEE: ${{ github.event.pull_request.user.login }}
-
     steps:
-      - name: Configure git and gh auth
-        run: |
-          gh auth status || gh auth login --with-token <<< "$GH_TOKEN"
-
       - name: Assign self to pull request
-        run: |
-          echo "Assigning PR #$NUMBER to $ASSIGNEE in $GH_REPO"
-          gh pr edit "$NUMBER" --add-assignee "$ASSIGNEE"
+        uses: actions-ecosystem/action-add-assignees@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          assignees: ${{ github.actor }}

--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -13,7 +13,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assign self to pull request
-        uses: actions-ecosystem/action-add-assignees@v1
+        uses: actions/github-script@v8
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          assignees: ${{ github.actor }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const assignee = context.payload.pull_request.user.login;
+            const issue_number = context.payload.pull_request.number;
+            
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue_number,
+              assignees: [assignee]
+            });


### PR DESCRIPTION
此 PR 通过重构使用 Action 而非 CLI 修复了 `Assign self to Pull Request` workflow 因总是失败导致其实际从未工作的问题。\
修改后的 workflow 已经过简单测试，参见[此处](https://github.com/QingFeng-awa/WorkflowTest/actions/runs/24578731062/job/71870767113)。

> 我不知道这个 workflow 存在的意义是什么，它看起来只是能让 GitHub 给你发邮件提醒*你刚刚创建了这个 PR*。\
> 但他坏到现在且一直没被删除我觉得应该有必要修复它，毕竟`Some checks were not successful`看起来不是那么美观。